### PR TITLE
fix Import error

### DIFF
--- a/src/ts.lua
+++ b/src/ts.lua
@@ -1,4 +1,4 @@
-local RoactPath = script.Parent:FindFirstAncestor("node_modules"):WaitForChild("roact").roact.src
+local RoactPath = script.Parent:FindFirstAncestor("node_modules"):WaitForChild("roact").src
 local Roact = require(RoactPath)
 local parent = script.Parent
 local createDragSource = require(parent.createDragSource)(Roact)


### PR DESCRIPTION
fix: roact is not a valid member of Folder "ReplicatedStorage.rbxts_include.node_modules.roact"
roact version: 1.4.0-ts.2